### PR TITLE
Updated README, fixed Makefile, and fixed bless_lambda.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,8 @@ publish:
 	mkdir -p ./publish/bless_lambda
 	cp -r ./bless ./publish/bless_lambda/
 	mv ./publish/bless_lambda/bless/aws_lambda/* ./publish/bless_lambda/
-	cp -r ./aws_lambda_libs/ ./publish/bless_lambda/
-	cp -r ./lambda_configs/ ./publish/bless_lambda/
-	rm ./publish/bless_lambda/place_cfg_and_pem_here ./publish/bless_lambda/place_compiled_dependencies_here
+	cp -r ./aws_lambda_libs/* ./publish/bless_lambda/
+	cp -r ./lambda_configs/* ./publish/bless_lambda/
 	cd ./publish/bless_lambda && zip -r ../bless_lambda.zip .
 
 .PHONY: develop dev-docs clean test lint coverage publish

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ $ source venv/bin/activate
     - venv/lib/python2.7/site-packages/*
     - venv/lib64/python2.7/site-packages/*
 
-- put those files in: ./aws-linux-libs/
+- put those files in: ./aws_lambda_libs/
 
 ### Protecting the CA Private Key
 - Generate a password protected RSA Private Key:

--- a/bless/aws_lambda/bless_lambda.py
+++ b/bless/aws_lambda/bless_lambda.py
@@ -61,7 +61,7 @@ def lambda_handler(event, context=None, ca_private_key_password=None,
     ca_private_key_file = ca_private_key_file.strip('"')
 
     # read the private key .pem
-    with open(ca_private_key_file, 'r') as f:
+    with open(os.path.join(os.path.dirname(__file__), ca_private_key_file), 'r') as f:
         ca_private_key = f.read()
 
     # decrypt ca private key password

--- a/bless/aws_lambda/bless_lambda.py
+++ b/bless/aws_lambda/bless_lambda.py
@@ -56,10 +56,6 @@ def lambda_handler(event, context=None, ca_private_key_password=None,
     ca_private_key_file = config.get(BLESS_CA_SECTION, CA_PRIVATE_KEY_FILE_OPTION)
     password_ciphertext_b64 = config.getpassword()
 
-    # Strip quotes from private key file path.
-    ca_private_key_file = ca_private_key_file.strip("'")
-    ca_private_key_file = ca_private_key_file.strip('"')
-
     # read the private key .pem
     with open(os.path.join(os.path.dirname(__file__), ca_private_key_file), 'r') as f:
         ca_private_key = f.read()

--- a/bless/aws_lambda/bless_lambda.py
+++ b/bless/aws_lambda/bless_lambda.py
@@ -56,8 +56,12 @@ def lambda_handler(event, context=None, ca_private_key_password=None,
     ca_private_key_file = config.get(BLESS_CA_SECTION, CA_PRIVATE_KEY_FILE_OPTION)
     password_ciphertext_b64 = config.getpassword()
 
+    # Strip quotes from private key file path.
+    ca_private_key_file = ca_private_key_file.strip("'")
+    ca_private_key_file = ca_private_key_file.strip('"')
+
     # read the private key .pem
-    with open(os.path.join(os.path.dirname(__file__), ca_private_key_file), 'r') as f:
+    with open(ca_private_key_file, 'r') as f:
         ca_private_key = f.read()
 
     # decrypt ca private key password


### PR DESCRIPTION
Fixed a couple issues:

It looks like the Makefile was slightly incorrect. It tried to delete a couple files that never exist and nested the Python dependencies and the BLESS configuration files in folders when your code assumes they are in the same directory as the executable. I got rid of the bad delete statements and got rid of the nesting.

Second one, the README states that you should put the Python libraries in a folder called `aws-linux-libs`, while the Makefile assumes that it is named `aws_lambda_libs`. I updated the README to reflect the actual name.

Other than that, everything works great! Thanks for putting this out there.