### PR TITLE
Update bless_client.py

### DIFF
--- a/bless_client/bless_client.py
+++ b/bless_client/bless_client.py
@@ -19,7 +19,8 @@ def main(argv):
             'Usage: bless_client.py region lambda_function_name bastion_user bastion_user_ip remote_username bastion_source_ip bastion_command <id_rsa.pub to sign> <output id_rsa-cert.pub>')
         return -1
 
-    if 'AWS_SECRET_ACCESS_KEY' not in os.environ:
+    credentials_file = os.path.join(os.environ['HOME'], '.aws', 'credentials')
+    if 'AWS_SECRET_ACCESS_KEY' not in os.environ and not os.path.isfile(credentials_file):
         print ('You need AWS credentials in your environment')
         return -1
 
@@ -36,7 +37,7 @@ def main(argv):
     print('Executing:')
     lambda_client = boto3.client('lambda', region_name=region)
     response = lambda_client.invoke(FunctionName=argv[1], InvocationType='RequestResponse',
-                                    LogType='Tail', Payload=payload_json)
+                                    LogType='None', Payload=payload_json)
     print('{}\n\n{}'.format(response['ResponseMetadata'], base64.b64decode(response['LogResult'])))
 
     if response['StatusCode'] != 200:

--- a/bless_client/bless_client.py
+++ b/bless_client/bless_client.py
@@ -6,7 +6,6 @@ Usage:
   bless_client.py region lambda_function_name bastion_user bastion_user_ip remote_username bastion_source_ip bastion_command <id_rsa.pub to sign> <output id_rsa-cert.pub>
 
 """
-import base64
 import json
 import sys
 
@@ -38,7 +37,7 @@ def main(argv):
     lambda_client = boto3.client('lambda', region_name=region)
     response = lambda_client.invoke(FunctionName=argv[1], InvocationType='RequestResponse',
                                     LogType='None', Payload=payload_json)
-    print('{}\n\n{}'.format(response['ResponseMetadata'], base64.b64decode(response['LogResult'])))
+    print('{}\n\n'.format(response['ResponseMetadata']))
 
     if response['StatusCode'] != 200:
         print ('Error creating cert.')


### PR DESCRIPTION
* Allow bless_client.py to accept ~/.aws/credentials
* Use LogType=None because the logs generally live in another account

As it stands, the recommendation to contain all BLESS items in a completely isolated account is one that I think is very reasonable. After setting that up and granting the appropriate cross-account perms to invoke the lambda, I ran into this issue. https://forums.aws.amazon.com/thread.jspa?messageID=715494
Because of that, I couldn't get it to work until I disabled the `LogType='Tail'` arg from the lambda handler invocation. I toyed w/ the idea of adding yet another param to `bless_client.py`, but I didn't think it warranted that. If there's a better way to get the logline of your request, let me know.
