### PR TITLE
Delegate AWS credential handling to AWS SDK

### DIFF
--- a/bless_client/bless_client.py
+++ b/bless_client/bless_client.py
@@ -19,10 +19,6 @@ def main(argv):
             'Usage: bless_client.py region lambda_function_name bastion_user bastion_user_ip remote_username bastion_source_ip bastion_command <id_rsa.pub to sign> <output id_rsa-cert.pub>')
         return -1
 
-    if 'AWS_SECRET_ACCESS_KEY' not in os.environ:
-        print ('You need AWS credentials in your environment')
-        return -1
-
     region = argv[0]
 
     with open(argv[7], 'r') as f:


### PR DESCRIPTION
boto3(AWS SDK) supports following aws credentials:: 

- credential file
- environment variable
- instance profile

http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#config-settings-and-precedence

but due to the validation,  `bless_client.py` only accepts environment variable credentials, so I changed `bless_client.py` to remove the validation and let boto3 take care of AWS credential handling.
I don't see any reason why only environment variable credentials are allowed.

This PR overlaps #9.