### PR TITLE
Make the 'extensions' included in the cert configurable

### DIFF
--- a/bless/config/bless_config.py
+++ b/bless/config/bless_config.py
@@ -18,6 +18,9 @@ RANDOM_SEED_BYTES_DEFAULT = 256
 LOGGING_LEVEL_OPTION = 'logging_level'
 LOGGING_LEVEL_DEFAULT = 'INFO'
 
+EXTENSIONS_OPTION = 'extensions'
+# Default for Extensions is None
+
 BLESS_CA_SECTION = 'Bless CA'
 CA_PRIVATE_KEY_FILE_OPTION = 'ca_private_key_file'
 KMS_KEY_ID_OPTION = 'kms_key_id'

--- a/bless/config/bless_deploy_example.cfg
+++ b/bless/config/bless_deploy_example.cfg
@@ -8,6 +8,8 @@ entropy_minimum_bits = 2048
 random_seed_bytes = 256
 # Set the logging level
 logging_level = INFO
+# Optionally set more restrictive extensions. Not specifying this uses the default extension set
+#extensions = permit-pty permit-user-rc permit-agent-forwarding
 
 # These values are all required to be modified for deployment
 [Bless CA]


### PR DESCRIPTION
This allows BLESS to be configured to limit the "extensions" in issued certificates. This is needed if you want to disallow port-forwarding, for example.