### PR TITLE
Example config - certificate_validity_seconds

### DIFF
--- a/bless/config/bless_deploy_example.cfg
+++ b/bless/config/bless_deploy_example.cfg
@@ -1,7 +1,7 @@
 # This section and its options are optional
 [Bless Options]
 # Number of seconds +/- the issued time for the certificate to be valid
-certificate_validity_window_seconds = 120
+certificate_validity_seconds = 120
 # Minimum number of bits in the system entropy pool before requiring an additional seeding step
 entropy_minimum_bits = 2048
 # Number of bytes of random to fetch from KMS to seed /dev/urandom


### PR DESCRIPTION
Had a "gotcha" when copy-pasting this file over. The variable is `certificate_validity_seconds` in code