### PR TITLE
Decouple configuration from deployment artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ included documentation.
 - Manage your bless_deploy.cfg files outside of this repo.
 - Provide your desired ./lambda_configs/bless_deploy.cfg prior to Publishing a new Lambda .zip
 - The required [Bless CA] option values must be set for your environment.
+- Every option can be changed in the environment. The environment variable name is contructed
+as section_name_option_name (all lowercase, spaces replaced with underscores).
 
 ### Publish Lambda .zip
 - Provide your desired ./lambda_configs/ca_key_name.pem prior to Publishing

--- a/bless/aws_lambda/bless_lambda.py
+++ b/bless/aws_lambda/bless_lambda.py
@@ -19,8 +19,6 @@ from bless.config.bless_config import BlessConfig, \
     CERTIFICATE_VALIDITY_AFTER_SEC_OPTION, \
     ENTROPY_MINIMUM_BITS_OPTION, \
     RANDOM_SEED_BYTES_OPTION, \
-    BLESS_CA_SECTION, \
-    CA_PRIVATE_KEY_FILE_OPTION, \
     LOGGING_LEVEL_OPTION, \
     KMSAUTH_SECTION, \
     KMSAUTH_USEKMSAUTH_OPTION, \
@@ -70,7 +68,7 @@ def lambda_handler(event, context=None, ca_private_key_password=None,
                                                        CERTIFICATE_VALIDITY_AFTER_SEC_OPTION)
     entropy_minimum_bits = config.getint(BLESS_OPTIONS_SECTION, ENTROPY_MINIMUM_BITS_OPTION)
     random_seed_bytes = config.getint(BLESS_OPTIONS_SECTION, RANDOM_SEED_BYTES_OPTION)
-    ca_private_key_file = config.get(BLESS_CA_SECTION, CA_PRIVATE_KEY_FILE_OPTION)
+    ca_private_key = config.getprivatekey()
     password_ciphertext_b64 = config.getpassword()
     certificate_extensions = config.get(BLESS_OPTIONS_SECTION, CERTIFICATE_EXTENSIONS_OPTION)
 
@@ -86,10 +84,6 @@ def lambda_handler(event, context=None, ca_private_key_password=None,
         request.bastion_user_ip,
         request.public_key_to_sign,
         request.kmsauth_token))
-
-    # read the private key .pem
-    with open(os.path.join(os.path.dirname(__file__), ca_private_key_file), 'r') as f:
-        ca_private_key = f.read()
 
     # decrypt ca private key password
     if ca_private_key_password is None:

--- a/bless/config/bless_config.py
+++ b/bless/config/bless_config.py
@@ -4,6 +4,7 @@
     :license: Apache, see LICENSE for more details.
 """
 import ConfigParser
+import base64
 import os
 
 BLESS_OPTIONS_SECTION = 'Bless Options'
@@ -33,6 +34,7 @@ CERTIFICATE_EXTENSIONS_DEFAULT = 'permit-X11-forwarding,' \
 
 BLESS_CA_SECTION = 'Bless CA'
 CA_PRIVATE_KEY_FILE_OPTION = 'ca_private_key_file'
+CA_PRIVATE_KEY_OPTION = 'ca_private_key'
 
 REGION_PASSWORD_OPTION_SUFFIX = '_password'
 
@@ -100,6 +102,16 @@ class BlessConfig(ConfigParser.RawConfigParser, object):
         :return: A list of kmsauth key ids
         """
         return map(str.strip, self.get(KMSAUTH_SECTION, KMSAUTH_KEY_ID_OPTION).split(','))
+
+    def getprivatekey(self):
+        if self.has_option(BLESS_CA_SECTION, CA_PRIVATE_KEY_OPTION):
+            return base64.b64decode(self.get(BLESS_CA_SECTION, CA_PRIVATE_KEY_OPTION))
+
+        ca_private_key_file = self.get(BLESS_CA_SECTION, CA_PRIVATE_KEY_FILE_OPTION)
+
+        # read the private key .pem
+        with open(os.path.join(os.path.dirname(__file__), ca_private_key_file), 'r') as f:
+            return f.read()
 
     def has_option(self, section, option):
         """

--- a/bless/config/bless_config.py
+++ b/bless/config/bless_config.py
@@ -81,14 +81,17 @@ class BlessConfig(ConfigParser.RawConfigParser, object):
             self.add_section(KMSAUTH_SECTION)
 
         if not self.has_option(BLESS_CA_SECTION, self.aws_region + REGION_PASSWORD_OPTION_SUFFIX):
-            raise ValueError("No Region Specific Password Provided.")
+            if not self.has_option(BLESS_CA_SECTION, 'default' + REGION_PASSWORD_OPTION_SUFFIX):
+                raise ValueError("No Region Specific And No Default Password Provided.")
 
     def getpassword(self):
         """
         Returns the correct encrypted password based off of the aws_region.
         :return: A Base64 encoded KMS CiphertextBlob.
         """
-        return self.get(BLESS_CA_SECTION, self.aws_region + REGION_PASSWORD_OPTION_SUFFIX)
+        if self.has_option(BLESS_CA_SECTION, self.aws_region + REGION_PASSWORD_OPTION_SUFFIX):
+            return self.get(BLESS_CA_SECTION, self.aws_region + REGION_PASSWORD_OPTION_SUFFIX)
+        return self.get(BLESS_CA_SECTION, 'default' + REGION_PASSWORD_OPTION_SUFFIX)
 
     def getkmsauthkeyids(self):
         """

--- a/bless/config/bless_deploy_example.cfg
+++ b/bless/config/bless_deploy_example.cfg
@@ -22,6 +22,8 @@ us-west-2_password = <INSERT_US-WEST-2_KMS_ENCRYPTED_BASE64_ENCODED_PEM_PASSWORD
 # default_password = <KMS_ENCRYPTED_BASE64_ENCODED_PEM_PASSWORD_HERE>
 # Specify the file name of your SSH CA's Private Key in PEM format.
 ca_private_key_file = <INSERT_YOUR_ENCRYPTED_PEM_FILE_NAME>
+# Or specify the private key directly as a base64 encoded string.
+# ca_private_key = <INSERT_YOUR_ENCRYPTED_PEM_FILE_CONTENT>
 
 # This section is optional
 [KMS Auth]

--- a/bless/config/bless_deploy_example.cfg
+++ b/bless/config/bless_deploy_example.cfg
@@ -18,6 +18,8 @@ logging_level = INFO
 # for each aws region specify a config option like '{}_password'.format(aws_region)
 us-east-1_password = <INSERT_US-EAST-1_KMS_ENCRYPTED_BASE64_ENCODED_PEM_PASSWORD_HERE>
 us-west-2_password = <INSERT_US-WEST-2_KMS_ENCRYPTED_BASE64_ENCODED_PEM_PASSWORD_HERE>
+# Or you can set a default password. Region specific password have precedence over the default
+# default_password = <KMS_ENCRYPTED_BASE64_ENCODED_PEM_PASSWORD_HERE>
 # Specify the file name of your SSH CA's Private Key in PEM format.
 ca_private_key_file = <INSERT_YOUR_ENCRYPTED_PEM_FILE_NAME>
 

--- a/tests/config/full-with-default.cfg
+++ b/tests/config/full-with-default.cfg
@@ -1,0 +1,14 @@
+[Bless Options]
+# The default values are sane, these are not.
+certificate_validity_after_seconds = 1
+certificate_validity_before_seconds = 1
+entropy_minimum_bits = 2
+random_seed_bytes = 3
+logging_level = DEBUG
+
+[Bless CA]
+kms_key_id = alias/foo
+us-east-1_password = <INSERT_US-EAST-1_KMS_ENCRYPTED_BASE64_ENCODED_PEM_PASSWORD_HERE>
+us-west-2_password = <INSERT_US-WEST-2_KMS_ENCRYPTED_BASE64_ENCODED_PEM_PASSWORD_HERE>
+default_password = <INSERT_DEFAULT_KMS_ENCRYPTED_BASE64_ENCODED_PEM_PASSWORD_HERE>
+ca_private_key_file = <INSERT_YOUR_ENCRYPTED_PEM_FILE_NAME>

--- a/tests/config/test_bless_config.py
+++ b/tests/config/test_bless_config.py
@@ -6,7 +6,9 @@ from bless.config.bless_config import BlessConfig, BLESS_OPTIONS_SECTION, \
     CERTIFICATE_VALIDITY_BEFORE_SEC_OPTION, CERTIFICATE_VALIDITY_AFTER_SEC_OPTION, \
     ENTROPY_MINIMUM_BITS_OPTION, RANDOM_SEED_BYTES_OPTION, \
     CERTIFICATE_VALIDITY_SEC_DEFAULT, ENTROPY_MINIMUM_BITS_DEFAULT, RANDOM_SEED_BYTES_DEFAULT, \
-    LOGGING_LEVEL_DEFAULT, LOGGING_LEVEL_OPTION
+    LOGGING_LEVEL_DEFAULT, LOGGING_LEVEL_OPTION, BLESS_CA_SECTION, \
+    CA_PRIVATE_KEY_FILE_OPTION, KMSAUTH_SECTION, KMSAUTH_USEKMSAUTH_OPTION, KMSAUTH_KEY_ID_OPTION, \
+    KMSAUTH_SERVICE_ID_OPTION, CERTIFICATE_EXTENSIONS_OPTION
 
 
 def test_empty_config():
@@ -19,6 +21,43 @@ def test_config_no_password():
         BlessConfig('bogus-region',
                     config_file=os.path.join(os.path.dirname(__file__), 'full.cfg'))
     assert 'No Region Specific Password Provided.' == e.value.message
+
+def test_config_environment_override(monkeypatch):
+    extra_environment_variables = {
+        'bless_options_certificate_validity_after_seconds': '1',
+        'bless_options_certificate_validity_before_seconds': '1',
+        'bless_options_entropy_minimum_bits': '2',
+        'bless_options_random_seed_bytes': '3',
+        'bless_options_logging_level': 'DEBUG',
+        'bless_options_certificate_extensions': 'permit-X11-forwarding',
+
+        'bless_ca_us-east-1_password': '<INSERT_US-EAST-1_KMS_ENCRYPTED_BASE64_ENCODED_PEM_PASSWORD_HERE>',
+        'bless_ca_ca_private_key_file': '<INSERT_YOUR_ENCRYPTED_PEM_FILE_NAME>',
+
+        'kms_auth_use_kmsauth': 'True',
+        'kms_auth_kmsauth_key_id': '<INSERT_ARN>',
+        'kms_auth_kmsauth_serviceid': 'bless-test',
+    }
+
+    for k,v in extra_environment_variables.items():
+        monkeypatch.setenv(k, v)
+
+    # Create an empty config, everything is set in the environment
+    config = BlessConfig('us-east-1', config_file='')
+
+    assert 1 == config.getint(BLESS_OPTIONS_SECTION, CERTIFICATE_VALIDITY_AFTER_SEC_OPTION)
+    assert 1 == config.getint(BLESS_OPTIONS_SECTION, CERTIFICATE_VALIDITY_BEFORE_SEC_OPTION)
+    assert 2 == config.getint(BLESS_OPTIONS_SECTION, ENTROPY_MINIMUM_BITS_OPTION)
+    assert 3 == config.getint(BLESS_OPTIONS_SECTION, RANDOM_SEED_BYTES_OPTION)
+    assert 'DEBUG' == config.get(BLESS_OPTIONS_SECTION, LOGGING_LEVEL_OPTION)
+    assert 'permit-X11-forwarding' == config.get(BLESS_OPTIONS_SECTION, CERTIFICATE_EXTENSIONS_OPTION)
+
+    assert '<INSERT_US-EAST-1_KMS_ENCRYPTED_BASE64_ENCODED_PEM_PASSWORD_HERE>' == config.getpassword()
+    assert '<INSERT_YOUR_ENCRYPTED_PEM_FILE_NAME>' == config.get(BLESS_CA_SECTION, CA_PRIVATE_KEY_FILE_OPTION)
+
+    assert config.getboolean(KMSAUTH_SECTION, KMSAUTH_USEKMSAUTH_OPTION)
+    assert '<INSERT_ARN>' == config.get(KMSAUTH_SECTION, KMSAUTH_KEY_ID_OPTION)
+    assert 'bless-test' == config.get(KMSAUTH_SECTION, KMSAUTH_SERVICE_ID_OPTION)
 
 
 @pytest.mark.parametrize(

--- a/tests/config/test_bless_config.py
+++ b/tests/config/test_bless_config.py
@@ -1,3 +1,4 @@
+import base64
 import os
 
 import pytest
@@ -6,7 +7,7 @@ from bless.config.bless_config import BlessConfig, BLESS_OPTIONS_SECTION, \
     CERTIFICATE_VALIDITY_BEFORE_SEC_OPTION, CERTIFICATE_VALIDITY_AFTER_SEC_OPTION, \
     ENTROPY_MINIMUM_BITS_OPTION, RANDOM_SEED_BYTES_OPTION, \
     CERTIFICATE_VALIDITY_SEC_DEFAULT, ENTROPY_MINIMUM_BITS_DEFAULT, RANDOM_SEED_BYTES_DEFAULT, \
-    LOGGING_LEVEL_DEFAULT, LOGGING_LEVEL_OPTION, BLESS_CA_SECTION, REGION_PASSWORD_OPTION_SUFFIX, \
+    LOGGING_LEVEL_DEFAULT, LOGGING_LEVEL_OPTION, BLESS_CA_SECTION, \
     CA_PRIVATE_KEY_FILE_OPTION, KMSAUTH_SECTION, KMSAUTH_USEKMSAUTH_OPTION, KMSAUTH_KEY_ID_OPTION, \
     KMSAUTH_SERVICE_ID_OPTION, CERTIFICATE_EXTENSIONS_OPTION
 
@@ -39,6 +40,7 @@ def test_config_environment_override(monkeypatch):
         'bless_ca_us-east-1_password': '<INSERT_US-EAST-1_KMS_ENCRYPTED_BASE64_ENCODED_PEM_PASSWORD_HERE>',
         'bless_ca_default_password': '<INSERT_DEFAULT_KMS_ENCRYPTED_BASE64_ENCODED_PEM_PASSWORD_HERE>',
         'bless_ca_ca_private_key_file': '<INSERT_YOUR_ENCRYPTED_PEM_FILE_NAME>',
+        'bless_ca_ca_private_key': base64.b64encode('<INSERT_YOUR_ENCRYPTED_PEM_FILE_CONTENT>'),
 
         'kms_auth_use_kmsauth': 'True',
         'kms_auth_kmsauth_key_id': '<INSERT_ARN>',
@@ -60,6 +62,7 @@ def test_config_environment_override(monkeypatch):
 
     assert '<INSERT_US-EAST-1_KMS_ENCRYPTED_BASE64_ENCODED_PEM_PASSWORD_HERE>' == config.getpassword()
     assert '<INSERT_YOUR_ENCRYPTED_PEM_FILE_NAME>' == config.get(BLESS_CA_SECTION, CA_PRIVATE_KEY_FILE_OPTION)
+    assert '<INSERT_YOUR_ENCRYPTED_PEM_FILE_CONTENT>' == config.getprivatekey()
 
     assert config.getboolean(KMSAUTH_SECTION, KMSAUTH_USEKMSAUTH_OPTION)
     assert '<INSERT_ARN>' == config.get(KMSAUTH_SECTION, KMSAUTH_KEY_ID_OPTION)


### PR DESCRIPTION
This PR makes it possible to deploy the same ZIP multiple times with a different configuration.

- Deploy the same zip in different regions, without changing the content. The extra `default_password` parameter is added so that you use an environment variable that has a name that does not change.
- Makes it easier to separate code and configuration deployments / privileges
- Allows key rotation without redeployment of the code.