### PR TITLE
Remove unused option 'kms_key_id'

### DIFF
--- a/bless/config/bless_config.py
+++ b/bless/config/bless_config.py
@@ -32,7 +32,6 @@ CERTIFICATE_EXTENSIONS_DEFAULT = 'permit-X11-forwarding,' \
 
 BLESS_CA_SECTION = 'Bless CA'
 CA_PRIVATE_KEY_FILE_OPTION = 'ca_private_key_file'
-KMS_KEY_ID_OPTION = 'kms_key_id'
 
 REGION_PASSWORD_OPTION_SUFFIX = '_password'
 

--- a/bless/config/bless_deploy_example.cfg
+++ b/bless/config/bless_deploy_example.cfg
@@ -14,8 +14,6 @@ logging_level = INFO
 
 # These values are all required to be modified for deployment
 [Bless CA]
-# AWS KMS key alias used to encrypt your private key password
-kms_key_id = <alias/key_name>
 # You must set an encrypted private key password for each AWS Region you deploy into
 # for each aws region specify a config option like '{}_password'.format(aws_region)
 us-east-1_password = <INSERT_US-EAST-1_KMS_ENCRYPTED_BASE64_ENCODED_PEM_PASSWORD_HERE>

--- a/tests/aws_lambda/bless-test-broken.cfg
+++ b/tests/aws_lambda/bless-test-broken.cfg
@@ -1,5 +1,4 @@
 [Bless CA]
 ca_private_key_file = ../../tests/aws_lambda/not-found.pem
-kms_key_id = alias/foo
 us-east-1_password = bogus-password-for-unit-test
 us-west-2_password = bogus-password-for-unit-test

--- a/tests/aws_lambda/bless-test-kmsauth.cfg
+++ b/tests/aws_lambda/bless-test-kmsauth.cfg
@@ -1,6 +1,5 @@
 [Bless CA]
 ca_private_key_file = ../../tests/aws_lambda/only-use-for-unit-tests.pem
-kms_key_id = alias/foo
 us-east-1_password = bogus-password-for-unit-test
 us-west-2_password = bogus-password-for-unit-test
 

--- a/tests/aws_lambda/bless-test-with-certificate-extensions-empty.cfg
+++ b/tests/aws_lambda/bless-test-with-certificate-extensions-empty.cfg
@@ -1,6 +1,5 @@
 [Bless CA]
 ca_private_key_file = ../../tests/aws_lambda/only-use-for-unit-tests.pem
-kms_key_id = alias/foo
 us-east-1_password = bogus-password-for-unit-test
 us-west-2_password = bogus-password-for-unit-tests
 

--- a/tests/aws_lambda/bless-test-with-certificate-extensions.cfg
+++ b/tests/aws_lambda/bless-test-with-certificate-extensions.cfg
@@ -1,6 +1,5 @@
 [Bless CA]
 ca_private_key_file = ../../tests/aws_lambda/only-use-for-unit-tests.pem
-kms_key_id = alias/foo
 us-east-1_password = bogus-password-for-unit-test
 us-west-2_password = bogus-password-for-unit-tests
 

--- a/tests/aws_lambda/bless-test-with-test-user.cfg
+++ b/tests/aws_lambda/bless-test-with-test-user.cfg
@@ -1,6 +1,5 @@
 [Bless CA]
 ca_private_key_file = ../../tests/aws_lambda/only-use-for-unit-tests.pem
-kms_key_id = alias/foo
 us-east-1_password = bogus-password-for-unit-test
 us-west-2_password = bogus-password-for-unit-tests
 

--- a/tests/aws_lambda/bless-test.cfg
+++ b/tests/aws_lambda/bless-test.cfg
@@ -1,5 +1,4 @@
 [Bless CA]
 ca_private_key_file = ../../tests/aws_lambda/only-use-for-unit-tests.pem
-kms_key_id = alias/foo
 us-east-1_password = bogus-password-for-unit-test
 us-west-2_password = bogus-password-for-unit-tests

--- a/tests/config/full.cfg
+++ b/tests/config/full.cfg
@@ -7,7 +7,6 @@ random_seed_bytes = 3
 logging_level = DEBUG
 
 [Bless CA]
-kms_key_id = alias/foo
 us-east-1_password = <INSERT_US-EAST-1_KMS_ENCRYPTED_BASE64_ENCODED_PEM_PASSWORD_HERE>
 us-west-2_password = <INSERT_US-WEST-2_KMS_ENCRYPTED_BASE64_ENCODED_PEM_PASSWORD_HERE>
 ca_private_key_file = <INSERT_YOUR_ENCRYPTED_PEM_FILE_NAME>

--- a/tests/config/minimal.cfg
+++ b/tests/config/minimal.cfg
@@ -1,5 +1,4 @@
 [Bless CA]
-kms_key_id = alias/foo
 us-west-2_password = <INSERT_KMS_ENCRYPTED_BASE64_ENCODED_PEM_PASSWORD_HERE>
 us-west-2_kms_context = {'insert': 'your context for us-west-2'}
 ca_private_key_file = <INSERT_YOUR_ENCRYPTED_PEM_FILE_NAME>


### PR DESCRIPTION
For decryption the key id is part of the ciphertext.