### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ addons:
 matrix:
   include:
     - python: "2.7"
+    - python: "3.6"
+  allow_failures:
+    - python: "3.6"
 
 install:
   - pip install coveralls

--- a/bless/config/bless_config.py
+++ b/bless/config/bless_config.py
@@ -3,10 +3,11 @@
     :copyright: (c) 2016 by Netflix Inc., see AUTHORS for more
     :license: Apache, see LICENSE for more details.
 """
-import ConfigParser
 import base64
 import os
 import re
+
+from six.moves import configparser
 
 BLESS_OPTIONS_SECTION = 'Bless Options'
 CERTIFICATE_VALIDITY_BEFORE_SEC_OPTION = 'certificate_validity_before_seconds'
@@ -59,7 +60,7 @@ REMOTE_USERNAMES_VALIDATION_OPTION = 'remote_usernames_validation'
 REMOTE_USERNAMES_VALIDATION_DEFAULT = 'principal'
 
 
-class BlessConfig(ConfigParser.RawConfigParser, object):
+class BlessConfig(configparser.RawConfigParser, object):
     def __init__(self, aws_region, config_file):
         """
         Parses the BLESS config file, and provides some reasonable default values if they are
@@ -86,7 +87,7 @@ class BlessConfig(ConfigParser.RawConfigParser, object):
                     USERNAME_VALIDATION_OPTION: USERNAME_VALIDATION_DEFAULT,
                     REMOTE_USERNAMES_VALIDATION_OPTION: REMOTE_USERNAMES_VALIDATION_DEFAULT
                     }
-        ConfigParser.RawConfigParser.__init__(self, defaults=defaults)
+        configparser.RawConfigParser.__init__(self, defaults=defaults)
         self.read(config_file)
 
         if not self.has_section(BLESS_OPTIONS_SECTION):

--- a/bless/ssh/protocol/ssh_protocol.py
+++ b/bless/ssh/protocol/ssh_protocol.py
@@ -6,6 +6,11 @@
 import binascii
 import struct
 
+try:
+    long        # Python 2
+except NameError:
+    long = int  # Python 3
+
 
 def pack_ssh_mpint(mpint):
     """

--- a/bless_client/bless_client.py
+++ b/bless_client/bless_client.py
@@ -31,17 +31,19 @@ Usage:
         "ssh will also try to load certificate information from the filename
         obtained by appending -cert.pub to identity filenames" e.g.  the <id_rsa.pub to sign>.
 """
+from __future__ import print_function
+
 import json
+import os
 import stat
 import sys
 
 import boto3
-import os
 
 
 def main(argv):
     if len(argv) < 9 or len(argv) > 10:
-        print (
+        print(
             'Usage: bless_client.py region lambda_function_name bastion_user bastion_user_ip '
             'remote_usernames bastion_ips bastion_command <id_rsa.pub to sign> '
             '<output id_rsa-cert.pub> [kmsauth token]')
@@ -71,13 +73,13 @@ def main(argv):
     print('{}\n'.format(response['ResponseMetadata']))
 
     if response['StatusCode'] != 200:
-        print ('Error creating cert.')
+        print('Error creating cert.')
         return -1
 
     payload = json.loads(response['Payload'].read())
 
     if 'certificate' not in payload:
-        print payload
+        print(payload)
         return -1
 
     cert = payload['certificate']

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,4 +30,4 @@ pytest==3.0.6
 pytest-mock==1.6.0
 python-dateutil==2.6.0
 s3transfer==0.1.10
-six==1.10.0
+six==1.11.0

--- a/tests/ssh/test_ssh_certificate_rsa.py
+++ b/tests/ssh/test_ssh_certificate_rsa.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import base64
 
 import pytest
@@ -139,7 +141,7 @@ def test_add_extensions():
     for extension in extensions:
         cert_builder.add_extension(extension)
 
-    print base64.b64encode(cert_builder._serialize_extensions())
+    print(base64.b64encode(cert_builder._serialize_extensions()))
     assert SSH_CERT_CUSTOM_EXTENSIONS == cert_builder._serialize_extensions()
 
 

--- a/tests/ssh/test_ssh_protocol.py
+++ b/tests/ssh/test_ssh_protocol.py
@@ -1,6 +1,11 @@
 import pytest
-from bless.ssh.protocol.ssh_protocol import pack_ssh_mpint, _hex_characters_length, \
-    pack_ssh_uint32, pack_ssh_uint64, pack_ssh_string
+from bless.ssh.protocol.ssh_protocol import (pack_ssh_mpint, _hex_characters_length,
+    pack_ssh_uint32, pack_ssh_uint64, pack_ssh_string)
+
+try:
+    long        # Python 2
+except NameError:
+    long = int  # Python 3
 
 
 def test_strings():


### PR DESCRIPTION
Some minimal, "safe" changes to make the code syntax compatible with both Python 2 and Python 3.

Still to be resolved:

$ __python3 -m flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./bless/ssh/protocol/ssh_protocol.py:52:27: F821 undefined name 'unicode'
    if isinstance(string, unicode):
                          ^
1     F821 undefined name 'unicode'
```