### PR TITLE
Add the FileSync flag to the zip command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ publish:
 	mv ./publish/bless_lambda/bless/aws_lambda/* ./publish/bless_lambda/
 	cp -r ./aws_lambda_libs/. ./publish/bless_lambda/
 	cp -r ./lambda_configs/. ./publish/bless_lambda/
-	cd ./publish/bless_lambda && zip -r ../bless_lambda.zip .
+	cd ./publish/bless_lambda && zip -FSr ../bless_lambda.zip .
 
 compile:
 	yum install -y gcc libffi-devel openssl-devel python27-virtualenv


### PR DESCRIPTION
When running "make publish" multiple times, the current behaviour is to accumulate files in the archive and can lead to multiple, sometimes conflicting versions of packages to be present in the zip.

Adding the "-FS" flag to the zip command ensures that the archive is fully synchronised.