### PR TITLE
Fix boolean value check on KMSAUTH_SECTION options

### DIFF
--- a/bless/aws_lambda/bless_lambda.py
+++ b/bless/aws_lambda/bless_lambda.py
@@ -142,7 +142,7 @@ def lambda_handler(event, context=None, ca_private_key_password=None, entropy_ch
         bypass_time_validity_check = False
 
     # Authenticate the user with KMS, if key is setup
-    if config.get(KMSAUTH_SECTION, KMSAUTH_USEKMSAUTH_OPTION):
+    if config.getboolean(KMSAUTH_SECTION, KMSAUTH_USEKMSAUTH_OPTION):
         if request.kmsauth_token:
             # Allow bless to sign the cert for a different remote user than the name of the user who signed it
             allowed_remotes = config.get(KMSAUTH_SECTION, KMSAUTH_REMOTE_USERNAMES_ALLOWED_OPTION)
@@ -154,7 +154,7 @@ def lambda_handler(event, context=None, ca_private_key_password=None, entropy_ch
                                           'unallowed remote_usernames [{}]'.format(request.remote_usernames))
 
                 # Check if the user is in the required IAM groups
-                if config.get(KMSAUTH_SECTION, VALIDATE_REMOTE_USERNAMES_AGAINST_IAM_GROUPS_OPTION):
+                if config.getboolean(KMSAUTH_SECTION, VALIDATE_REMOTE_USERNAMES_AGAINST_IAM_GROUPS_OPTION):
                     iam = boto3.client('iam')
                     user_groups = iam.list_groups_for_user(UserName=request.bastion_user)
 


### PR DESCRIPTION
Fix a logical error when checking the value of the KMSAUTH_USEKMSAUTH_OPTION and VALIDATE_REMOTE_USERNAMES_AGAINST_IAM_GROUPS_OPTION configuration variables.  

The current implementation uses config.get(), which simply returns a string, and the logical test that follows becomes a test for a non-empty string as a result.  A configuration value of 'false' or 'true' falls through.

This fix updates the if-condition to use config.getboolean() instead of config.get(), which seems to be the recommended method enforced by the unit test. 

@see https://github.com/Netflix/bless/blob/master/tests/config/test_bless_config.py#L150
