### PR TITLE
With the existence of more SSH certificate tools since the release of…

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -1,0 +1,1 @@
+This project is deprecated and will no longer be addressing issues.

--- a/OSSMETADATA
+++ b/OSSMETADATA
@@ -1,1 +1,1 @@
-osslifecycle=active
+osslifecycle=archived

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# Archived
+With the existence of more SSH certificate tools since the release of BLESS, and better SSH access management from AWS, we're moving BLESS to the archived OSS project state. This means we no longer plan to maintain the project, but will be keeping it public for others who may still use it.
+
 ![alt text](bless_logo.png "BLESS")
 # BLESS - Bastion's Lambda Ephemeral SSH Service
 [![Build Status](https://travis-ci.org/Netflix/bless.svg?branch=master)](https://travis-ci.org/Netflix/bless) [![Test coverage](https://coveralls.io/repos/github/Netflix/bless/badge.svg?branch=master)](https://coveralls.io/github/Netflix/bless) [![Join the chat at https://gitter.im/Netflix/bless](https://badges.gitter.im/Netflix/bless.svg)](https://gitter.im/Netflix/bless?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![NetflixOSS Lifecycle](https://img.shields.io/osslifecycle/Netflix/bless.svg)]()


### PR DESCRIPTION
… BLESS, and better SSH access management from AWS, we're moving BLESS to the archived OSS project state. This means we no longer plan to maintain the project, but will be keeping it public for others who may still use it.