### PR TITLE
docs: fix simple typo, connfig -> config

### DIFF
--- a/bless/config/bless_config.py
+++ b/bless/config/bless_config.py
@@ -89,7 +89,7 @@ class BlessConfig(configparser.RawConfigParser, object):
 
         The [Bless CA] section is required.
         :param aws_region: The AWS Region BLESS is deployed to.
-        :param config_file: Path to the connfig file.
+        :param config_file: Path to the config file.
         """
         self.aws_region = aws_region
         defaults = {CERTIFICATE_VALIDITY_BEFORE_SEC_OPTION: CERTIFICATE_VALIDITY_SEC_DEFAULT,


### PR DESCRIPTION
There is a small typo in bless/config/bless_config.py.

Should read `config` rather than `connfig`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md